### PR TITLE
Fixed issue where clicking View in Toolbar didn't display View name

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Toolbar.php file
     
     public array $collectors = [
         ...
+        //Views::class,
         Twig::class
     ];
 

--- a/src/Debug/Toolbar/Collectors/Twig.php
+++ b/src/Debug/Toolbar/Collectors/Twig.php
@@ -49,7 +49,7 @@ class Twig extends BaseCollector
      *
      * @var string
      */
-    protected $title = 'Twig';
+    protected $title = 'Views';
 
     /**
      * Instance of the shared Renderer service

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -205,19 +205,28 @@ class Twig
 
         $output = $this->twig->render($view, $params);
 
-        if ($this->debug) {
-            $this->logPerformance($start, microtime(true), $view);
+		// Check if DebugToolbar is enabled.
+		$filters              = service('filters');
+		$requiredAfterFilters = $filters->getRequiredFilters('after')[0];
 
-            if (in_array(DebugToolbar::class, service('filters')->getFiltersClass()['after'], true)) {
-                $toolbarCollectors = config(Toolbar::class)->collectors;
+		if (in_array('toolbar', $requiredAfterFilters, true)) {
+			$debugBarEnabled = true;
+		} else {
+			$afterFilters    = $filters->getFiltersClass()['after'];
+			$debugBarEnabled = in_array(DebugToolbar::class, $afterFilters, true);
+		}
 
-                if (in_array(CollectorsTwig::class, $toolbarCollectors, true)) {
-                    $output = '<!-- DEBUG-VIEW START ' . $view . ' -->' . PHP_EOL
-                        . $output . PHP_EOL
-                        . '<!-- DEBUG-VIEW ENDED ' . $view . ' -->' . PHP_EOL;
-                }
-            }
-        }
+		if ($this->debug && $debugBarEnabled) {
+			$this->logPerformance($start, microtime(true), $view);
+
+			$toolbarCollectors = config(Toolbar::class)->collectors;
+
+			if (in_array(CollectorsTwig::class, $toolbarCollectors, true)) {
+				$output = '<!-- DEBUG-VIEW START ' . $view . ' -->' . PHP_EOL
+					. $output . PHP_EOL
+					. '<!-- DEBUG-VIEW ENDED ' . $view . ' -->' . PHP_EOL;
+			}
+		}
 
         $this->tempData = null;
 


### PR DESCRIPTION
In toolbar.js, when data-tab='ci-views' is clicked, the view name is displayed. ci-views uses the Collector's title directly. If you want to change the title, you need to add new JS processing.